### PR TITLE
make 401 and 404 return json rather than html

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -160,6 +160,16 @@ fn me(user: User) -> Api<auth::UserResponse> {
     Ok(Json(auth::UserResponse::new(user)))
 }
 
+#[catch(401)]
+fn unauthorized() -> ApiError {
+    ApiError::unauthorized()
+}
+
+#[catch(404)]
+fn not_found() -> Api<()> {
+    ApiError::not_found(None, "Endpoint not found".to_string())
+}
+
 // Main entry that creates the web application, connects to the database and binds the web routes
 pub fn rocket() -> Rocket {
     dotenv::dotenv().ok(); // read from a .env file if one is present
@@ -172,6 +182,7 @@ pub fn rocket() -> Rocket {
         .attach(Template::fairing())
         .attach(https::ProductionHttpsRedirect {})
         .attach(hsts::sts_header())
+        .register(catchers![unauthorized, not_found])
         .mount("/", routes![admin, https::redirect_handler])
         .mount("/api", routes![
             login, logout, register, start_reset_password, reset_password, me,

--- a/tests/photo_albums.rs
+++ b/tests/photo_albums.rs
@@ -34,6 +34,15 @@ fn photo_albums() {
     let email = String::from("photo@testing.com");
     let creds = json!({ "email": &email, "password": "ninja truck bar fight" });
 
+    // make sure the authenticated endpoints 401 json and not html
+    let mut res = post(&client, "/api/albums/1/publish", &json!({"foo": "bar"}), None);
+    let body = serde_json::from_str(&res.body_string().expect("missing body on login"))
+        .expect("401 body parsing failed");
+    match body {
+        Value::Object(_map) => (),
+        _ => assert!(false, "didn't get object back for 401 response"),
+    }
+
     // register a new user & log in
     let res = register(&creds);
     assert_eq!(res.status(), Status::Ok);


### PR DESCRIPTION
ran into this while doing some ui dev, the json parsing kept failing which would break everything on the page on 404 and 401s 